### PR TITLE
Fix GitHub Pages permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.18.0
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: touch out/.nojekyll
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+


### PR DESCRIPTION
## Summary
- specify `contents: write` permission for the GitHub Pages workflow

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_68418bfecab0832fab4b82ae21ff84b2