### PR TITLE
Fix asset paths in PR preview builds

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,6 +15,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
       - run: touch out/.nojekyll
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,14 @@
 /** @type {import('next').NextConfig} */
+const repoName = 'm2-prototype';
+const prNumber = process.env.PR_NUMBER;
+const prSegment = prNumber ? `/pr-${prNumber}` : '';
+const basePath = `/${repoName}${prSegment}`;
+
 const nextConfig = {
   reactStrictMode: true,
   output: 'export',
-  basePath: '/m2-prototype',
-  assetPrefix: '/m2-prototype/',
+  basePath,
+  assetPrefix: `${basePath}/`,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js to set `basePath` and `assetPrefix` dynamically when `PR_NUMBER` is provided
- pass `PR_NUMBER` from the PR workflow so preview builds serve assets from `/pr-*`

## Testing
- `npm run build`
- `npx next lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9363020832fb6ab38f9e2ff5aa8