### PR TITLE
Add Russian menu structure and pages

### DIFF
--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -1,18 +1,65 @@
 import Link from 'next/link';
 
+interface Item {
+  title: string;
+  slug: string;
+  icon: string;
+}
+
+const popular: Item[] = [
+  { title: 'Ипотека', slug: '/ipoteka', icon: '💰' },
+  { title: 'Сделка', slug: '/sdelka', icon: '📝' },
+  { title: 'Защита сделки', slug: '/zashchita-sdelki', icon: '🛡️' },
+  { title: 'Проверка недвижимости', slug: '/proverka-nedvizhimosti', icon: '🏢' },
+];
+
+const highCommission: Item[] = [
+  { title: 'Свой дом', slug: '/svoy-dom', icon: '🏡' },
+  { title: 'M2Pro Новостройки', slug: '/m2pro-novostroyki', icon: '🏗️' },
+];
+
+const bottom: Item[] = [
+  { title: 'Помощь', slug: '/pomoshch', icon: '❓' },
+  { title: 'Обучение', slug: '/obuchenie', icon: '📚' },
+  { title: 'Профиль', slug: '/profil', icon: '👤' },
+  { title: 'Выход', slug: '/vyhod', icon: '🚪' },
+];
+
 export default function Menu() {
   return (
     <nav>
-      <ul>
-        <li>
-          <Link href="/">Home</Link>
+      <ul className="menu-top">
+        <li className="menu-item">
+          <Link href="/">Главная<span className="menu-icon">🏠</span></Link>
         </li>
-        <li>
-          <a href="#">About</a>
-        </li>
-        <li>
-          <a href="#">Contact</a>
-        </li>
+        <li className="menu-section-title">Популярные сервисы</li>
+        {popular.map((item) => (
+          <li key={item.slug} className="menu-item">
+            <Link href={item.slug}>
+              {item.title}
+              <span className="menu-icon">{item.icon}</span>
+            </Link>
+          </li>
+        ))}
+        <li className="menu-section-title">С высокой комиссией</li>
+        {highCommission.map((item) => (
+          <li key={item.slug} className="menu-item">
+            <Link href={item.slug}>
+              {item.title}
+              <span className="menu-icon">{item.icon}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <ul className="menu-bottom">
+        {bottom.map((item) => (
+          <li key={item.slug} className="menu-item">
+            <Link href={item.slug}>
+              {item.title}
+              <span className="menu-icon">{item.icon}</span>
+            </Link>
+          </li>
+        ))}
       </ul>
     </nav>
   );

--- a/pages/ipoteka.tsx
+++ b/pages/ipoteka.tsx
@@ -1,0 +1,8 @@
+export default function Ipoteka() {
+  return (
+    <div>
+      <h1>Ипотека</h1>
+      <p>Страница "Ипотека".</p>
+    </div>
+  );
+}

--- a/pages/m2pro-novostroyki.tsx
+++ b/pages/m2pro-novostroyki.tsx
@@ -1,0 +1,8 @@
+export default function m2pro_novostroyki() {
+  return (
+    <div>
+      <h1>M2Pro Новостройки</h1>
+      <p>Страница "M2Pro Новостройки".</p>
+    </div>
+  );
+}

--- a/pages/obuchenie.tsx
+++ b/pages/obuchenie.tsx
@@ -1,0 +1,8 @@
+export default function obuchenie() {
+  return (
+    <div>
+      <h1>Обучение</h1>
+      <p>Страница "Обучение".</p>
+    </div>
+  );
+}

--- a/pages/pomoshch.tsx
+++ b/pages/pomoshch.tsx
@@ -1,0 +1,8 @@
+export default function pomoshch() {
+  return (
+    <div>
+      <h1>Помощь</h1>
+      <p>Страница "Помощь".</p>
+    </div>
+  );
+}

--- a/pages/profil.tsx
+++ b/pages/profil.tsx
@@ -1,0 +1,8 @@
+export default function profil() {
+  return (
+    <div>
+      <h1>Профиль</h1>
+      <p>Страница "Профиль".</p>
+    </div>
+  );
+}

--- a/pages/proverka-nedvizhimosti.tsx
+++ b/pages/proverka-nedvizhimosti.tsx
@@ -1,0 +1,8 @@
+export default function proverka_nedvizhimosti() {
+  return (
+    <div>
+      <h1>Проверка недвижимости</h1>
+      <p>Страница "Проверка недвижимости".</p>
+    </div>
+  );
+}

--- a/pages/sdelka.tsx
+++ b/pages/sdelka.tsx
@@ -1,0 +1,8 @@
+export default function sdelka() {
+  return (
+    <div>
+      <h1>Сделка</h1>
+      <p>Страница "Сделка".</p>
+    </div>
+  );
+}

--- a/pages/svoy-dom.tsx
+++ b/pages/svoy-dom.tsx
@@ -1,0 +1,8 @@
+export default function svoy_dom() {
+  return (
+    <div>
+      <h1>Свой дом</h1>
+      <p>Страница "Свой дом".</p>
+    </div>
+  );
+}

--- a/pages/vyhod.tsx
+++ b/pages/vyhod.tsx
@@ -1,0 +1,8 @@
+export default function vyhod() {
+  return (
+    <div>
+      <h1>Выход</h1>
+      <p>Страница "Выход".</p>
+    </div>
+  );
+}

--- a/pages/zashchita-sdelki.tsx
+++ b/pages/zashchita-sdelki.tsx
@@ -1,0 +1,8 @@
+export default function zashchita_sdelki() {
+  return (
+    <div>
+      <h1>Защита сделки</h1>
+      <p>Страница "Защита сделки".</p>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,3 +50,35 @@ body {
 main {
   padding: 20px;
 }
+
+.side-menu nav {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.menu-top,
+.menu-bottom {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.menu-bottom {
+  margin-top: auto;
+}
+
+.menu-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+}
+
+.menu-section-title {
+  font-weight: bold;
+  margin-top: 20px;
+}
+
+.menu-icon {
+  margin-left: 8px;
+}


### PR DESCRIPTION
## Summary
- implement sidebar menu with Russian items and emojis
- create pages for each service item
- style menu for bottom-pinned links

## Testing
- `npm run lint` *(fails: requires interactive eslint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6842a0c341bc832f8ed3932b0bbceb2c