### PR TITLE
Add connect-to-telegram page

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -24,7 +24,7 @@ export default function Layout({ children }: Props) {
       <div className={`side-menu ${open ? 'open' : ''}`}>
         <Menu />
       </div>
-      <main>{children}</main>
+      <main className="content">{children}</main>
     </div>
   );
 }

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -7,6 +7,7 @@ interface Item {
 }
 
 const popular: Item[] = [
+  { title: 'Секретарь', slug: '/sekretar', icon: '🤖' },
   { title: 'Ипотека', slug: '/ipoteka', icon: '💰' },
   { title: 'Сделка', slug: '/sdelka', icon: '📝' },
   { title: 'Защита сделки', slug: '/zashchita-sdelki', icon: '🛡️' },

--- a/pages/sekretar.tsx
+++ b/pages/sekretar.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link';
+
+export default function Sekretar() {
+  return (
+    <div>
+      <h1>Секретарь</h1>
+      <p>
+        Наш бот помогает вам быстро запустить автоматизацию общения с клиентами.
+        Вы больше не потеряете клиентов! У вас появится дополнительное время,
+        которое вы сможете потратить на себя или на другие рабочие задачи!
+        Выберите подходящий тариф и начните прямо сейчас!
+      </p>
+      <div className="tariff-cards">
+        <div className="tariff-card inactive">
+          <h2>Старт</h2>
+          <p className="price">999₽ в месяц</p>
+          <ul>
+            <li>Telegram</li>
+            <li>Базовые типовые сценарии</li>
+            <li>Интеграция с CRM</li>
+            <li>Базовая аналитика</li>
+          </ul>
+        </div>
+        <div className="tariff-card inactive">
+          <h2>Про</h2>
+          <p className="price">1999₽ в месяц</p>
+          <ul>
+            <li>Включает все предыдущие пункты</li>
+            <li>WhatsApp</li>
+            <li>AI ответы</li>
+            <li>Перехват диалога</li>
+          </ul>
+        </div>
+        <Link href="/sekretar/connect-to-telegram/" className="tariff-card">
+          <h2>Макси</h2>
+          <p className="price">2999₽ в месяц</p>
+          <p className="note">Первый месяц бесплатно</p>
+          <ul>
+            <li>Включает все предыдущие пункты</li>
+            <li>VK</li>
+            <li>Запись на показы</li>
+            <li>Расширенная аналитика</li>
+            <li>Сайт-визитка</li>
+          </ul>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/pages/sekretar/connect-to-telegram.tsx
+++ b/pages/sekretar/connect-to-telegram.tsx
@@ -1,0 +1,201 @@
+import { useRef, useState } from 'react';
+import Head from 'next/head';
+
+interface MenuOption {
+  text: string;
+  callback_data: string;
+}
+
+interface Message {
+  sender: 'user' | 'bot';
+  text: string;
+  menu?: MenuOption[];
+}
+
+const dialogSequence: Message[] = [
+  { sender: 'bot', text: 'Привет! Чем могу помочь?' },
+  { sender: 'user', text: 'Привет, бот!' },
+  {
+    sender: 'bot',
+    text: 'Пожалуйста, выберите опцию:',
+    menu: [
+      { text: 'Опция 1', callback_data: 'option1' },
+      { text: 'Опция 2', callback_data: 'option2' },
+      { text: 'Другая опция', callback_data: 'option3' },
+    ],
+  },
+  { sender: 'user', text: 'Расскажи о погоде.' },
+  { sender: 'bot', text: 'Сегодня солнечно и тепло.' },
+  { sender: 'user', text: 'Отлично! А что насчет новостей?' },
+  { sender: 'bot', text: 'Последние новости доступны на нашем сайте.' },
+  { sender: 'user', text: 'Понятно. Спасибо!' },
+  { sender: 'bot', text: 'Всегда рад помочь!' },
+];
+
+export default function ConnectToTelegram() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dialogIndex = useRef(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const addMessage = (msg: Message) => {
+    setMessages((prev) => [...prev, msg]);
+    setTimeout(() => {
+      containerRef.current?.scrollTo(0, containerRef.current.scrollHeight);
+    }, 0);
+  };
+
+  const handleMenuSelection = (selectedText: string, callback: string) => {
+    addMessage({ sender: 'user', text: `Выбрано: ${selectedText}` });
+    let botResponse = '';
+    switch (callback) {
+      case 'option1':
+        botResponse = 'Вы выбрали Опцию 1. Вот информация по ней...';
+        break;
+      case 'option2':
+        botResponse = 'Опция 2 выбрана. Что бы вы хотели узнать дальше?';
+        break;
+      case 'option3':
+        botResponse = 'Вы выбрали "Другая опция". Уточните ваш запрос.';
+        break;
+      default:
+        botResponse = 'Неизвестная опция.';
+    }
+    setTimeout(() => addMessage({ sender: 'bot', text: botResponse }), 1000);
+  };
+
+  const sendUserMessage = () => {
+    const text = inputRef.current?.value.trim();
+    if (text) {
+      addMessage({ sender: 'user', text });
+      if (inputRef.current) inputRef.current.value = '';
+    }
+
+    if (dialogIndex.current < dialogSequence.length) {
+      const next = dialogSequence[dialogIndex.current];
+      setTimeout(() => {
+        addMessage(next);
+        dialogIndex.current += 1;
+      }, next.sender === 'bot' ? 1000 : 0);
+    } else {
+      setTimeout(
+        () => addMessage({ sender: 'bot', text: 'Диалог завершен. Если у вас есть еще вопросы, начните новый.' }),
+        1000,
+      );
+    }
+  };
+
+  // init first message
+  if (messages.length === 0 && dialogIndex.current === 0) {
+    const first = dialogSequence[0];
+    addMessage(first);
+    dialogIndex.current = 1;
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Telegram Bot Chat</title>
+      </Head>
+      <div className="chat-container">
+        <div className="messages" ref={containerRef}>
+          {messages.map((msg, idx) => (
+            <div key={idx} className={`message ${msg.sender}`}>
+              <span>{msg.text}</span>
+              {msg.sender === 'bot' && msg.menu && (
+                <div style={{ marginTop: '5px' }}>
+                  {msg.menu.map((option) => (
+                    <button
+                      key={option.callback_data}
+                      className="inline-menu-button"
+                      onClick={() => handleMenuSelection(option.text, option.callback_data)}
+                    >
+                      {option.text}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="input-area">
+          <input ref={inputRef} type="text" placeholder="Введите сообщение..." onKeyPress={(e) => e.key === 'Enter' && sendUserMessage()} />
+          <button onClick={sendUserMessage}>Отправить</button>
+        </div>
+      </div>
+      <style jsx>{`
+        .chat-container {
+          width: 400px;
+          height: 600px;
+          border: 1px solid #ccc;
+          background-color: #fff;
+          display: flex;
+          flex-direction: column;
+          border-radius: 8px;
+          box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+          margin: 40px auto;
+        }
+        .messages {
+          flex-grow: 1;
+          overflow-y: auto;
+          padding: 10px;
+          display: flex;
+          flex-direction: column;
+        }
+        .message {
+          padding: 8px 12px;
+          margin-bottom: 8px;
+          border-radius: 18px;
+          max-width: 70%;
+          word-wrap: break-word;
+          cursor: pointer;
+        }
+        .user {
+          background-color: #dcf8c6;
+          align-self: flex-end;
+          border-bottom-right-radius: 4px;
+        }
+        .bot {
+          background-color: #f1f0f0;
+          align-self: flex-start;
+          border-bottom-left-radius: 4px;
+        }
+        .inline-menu-button {
+          background-color: #fff;
+          border: 1px solid #007bff;
+          color: #007bff;
+          padding: 8px 12px;
+          margin-top: 5px;
+          margin-right: 5px;
+          border-radius: 15px;
+          cursor: pointer;
+          display: inline-block;
+        }
+        .inline-menu-button:hover {
+          background-color: #007bff;
+          color: #fff;
+        }
+        .input-area {
+          padding: 10px;
+          border-top: 1px solid #ccc;
+          display: flex;
+        }
+        .input-area input {
+          flex-grow: 1;
+          padding: 10px;
+          border: 1px solid #ddd;
+          border-radius: 20px;
+          margin-right: 10px;
+        }
+        .input-area button {
+          padding: 10px 15px;
+          border: none;
+          background-color: #007bff;
+          color: white;
+          border-radius: 20px;
+          cursor: pointer;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -51,6 +51,11 @@ main {
   padding: 20px;
 }
 
+.content {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
 .side-menu nav {
   display: flex;
   flex-direction: column;
@@ -81,4 +86,33 @@ main {
 
 .menu-icon {
   margin-left: 8px;
+}
+
+.tariff-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.tariff-card {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 16px;
+  width: 200px;
+}
+
+.tariff-card .price {
+  font-weight: bold;
+  margin: 8px 0;
+}
+
+.tariff-card .note {
+  font-size: 0.9em;
+  color: #555;
+  margin-bottom: 8px;
+}
+
+.tariff-card.inactive {
+  opacity: 0.5;
 }


### PR DESCRIPTION
## Summary
- make tariff "Макси" link to `/sekretar/connect-to-telegram/`
- implement connect-to-telegram page with sample chat UI
- keep Layout main content width limit

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6842b80484e4832f8805a29ee0a31485